### PR TITLE
Set akka remoting port to 0

### DIFF
--- a/ch2/akkademy-db-client-java/src/main/resources/application.conf
+++ b/ch2/akkademy-db-client-java/src/main/resources/application.conf
@@ -3,4 +3,5 @@ akka {
   actor {
     provider = "akka.remote.RemoteActorRefProvider"
   }
+  remote.netty.tcp.port = 0
 }


### PR DESCRIPTION
This fix sets akka remoting port to 0, so that it's automatically
assigned - this way it won't collide with port 2552 used by
akkademy-db. We are the client so we don't care what port we
are listening on.