### PR TITLE
fixed some minor issues

### DIFF
--- a/ch3/akkademaid-scala/src/main/scala/com/akkademy/TellDemoArticleParser.scala
+++ b/ch3/akkademaid-scala/src/main/scala/com/akkademy/TellDemoArticleParser.scala
@@ -9,12 +9,12 @@ import com.akkademy.messages.{GetRequest, SetRequest}
 
 class TellDemoArticleParser(cacheActorPath: String,
                             httpClientActorPath: String,
-                            acticleParserActorPath: String,
+                            articleParserActorPath: String,
                             implicit val timeout: Timeout
                              ) extends Actor {
   val cacheActor = context.actorSelection(cacheActorPath)
   val httpClientActor = context.actorSelection(httpClientActorPath)
-  val articleParserActor = context.actorSelection(acticleParserActorPath)
+  val articleParserActor = context.actorSelection(articleParserActorPath)
 
   implicit val ec = context.dispatcher
 
@@ -28,12 +28,12 @@ class TellDemoArticleParser(cacheActorPath: String,
    */
 
   override def receive: Receive = {
-    case msg @ ParseArticle(uri) =>
+    case ParseArticle(uri) =>
 
       val extraActor = buildExtraActor(sender(), uri)
 
       cacheActor.tell(GetRequest(uri), extraActor)
-      httpClientActor.tell("test", extraActor)
+      httpClientActor.tell(uri, extraActor)
 
       context.system.scheduler.scheduleOnce(timeout.duration, extraActor, "timeout")
   }


### PR DESCRIPTION
- fixed typo (articleParserActorPath instead of acticleParserActorPath)
- removed not required pattern binder (msg@) with ParseArticle message handling
- send target uri to HttpClientActor rather than hardcoded "text"
