### PR TITLE
Ch 2 Scala: Set akka remoting port to 0

### DIFF
--- a/ch2/akkademy-db-client-scala/src/main/resources/application.conf
+++ b/ch2/akkademy-db-client-scala/src/main/resources/application.conf
@@ -2,4 +2,5 @@ akka {
   actor {
     provider = "akka.remote.RemoteActorRefProvider"
   }
+  remote.netty.tcp.port = 0
 }


### PR DESCRIPTION
Learning scala / akka through your book and was getting collisions on port 2552 while running the provided test. I see that this is how the java version was fixed in the past via an older pull request.